### PR TITLE
Update build workflow for new DuckDB release (`v1.4.4`)

### DIFF
--- a/.github/workflows/dist_pipeline.yml
+++ b/.github/workflows/dist_pipeline.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -30,10 +30,10 @@ jobs:
       exclude_archs: "windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_eh;wasm_threads"
 
   duckdb-stable-build:
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.3
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.4
     with:
-      duckdb_version: v1.4.3
-      ci_tools_version: v1.4.3
+      duckdb_version: v1.4.4
+      ci_tools_version: v1.4.4
       extension_name: gaggle
       enable_rust: true
       exclude_archs: "windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_eh;wasm_threads"

--- a/gaggle/Cargo.toml
+++ b/gaggle/Cargo.toml
@@ -36,7 +36,7 @@ proptest = "1.5"
 opt-level = 3
 lto = true
 codegen-units = 1
-panic = "abort"
+panic = "unwind"
 
 [profile.dev]
 opt-level = 0

--- a/gaggle/Cargo.toml
+++ b/gaggle/Cargo.toml
@@ -18,8 +18,8 @@ parking_lot = "0.12"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["blocking", "rustls-tls", "json", "multipart"], default-features = false }
-zip = { version = "6.0", default-features = false, features = ["deflate"] }
+reqwest = { version = "=0.12", features = ["blocking", "rustls-tls", "json", "multipart"], default-features = false }
+zip = { version = "7.2", default-features = false, features = ["deflate"] }
 dirs = "6.0"
 urlencoding = "2.1"
 tracing = "0.1"


### PR DESCRIPTION
* Updated the build workflow for the new DuckDB release (`v1.4.4`).