### PR TITLE
Update build workflow for new DuckDB release (v1.5.3)

### DIFF
--- a/.github/workflows/dist_pipeline.yml
+++ b/.github/workflows/dist_pipeline.yml
@@ -37,10 +37,10 @@ jobs:
       exclude_archs: "windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_eh;wasm_threads"
 
   duckdb-stable-build:
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.2
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.3
     with:
-      duckdb_version: v1.5.2
-      ci_tools_version: v1.5.2
+      duckdb_version: v1.5.3
+      ci_tools_version: v1.5.3
       extension_name: gaggle
       enable_rust: true
       exclude_archs: "windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_eh;wasm_threads"


### PR DESCRIPTION
* Updated build workflow for new DuckDB release (v1.5.3).
* Updated the external dependencies (Git submodules).