### PR TITLE
Update build workflow for new DuckDB release (`v1.5.4`)

### DIFF
--- a/.github/workflows/dist_pipeline.yml
+++ b/.github/workflows/dist_pipeline.yml
@@ -37,10 +37,10 @@ jobs:
       exclude_archs: "windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_eh;wasm_threads"
 
   duckdb-stable-build:
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.3
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.4
     with:
-      duckdb_version: v1.5.3
-      ci_tools_version: v1.5.3
+      duckdb_version: v1.5.4
+      ci_tools_version: v1.5.4
       extension_name: gaggle
       enable_rust: true
       exclude_archs: "windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_eh;wasm_threads"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Priorities, in order:
 - `docs/examples/`: SQL examples that should remain runnable against a local build.
 - `.github/workflows/tests.yml`: Rust tests and SQL tests in CI.
 - `.github/workflows/lints.yml`: Rust formatting and clippy checks in CI.
-- `.github/workflows/dist_pipeline.yml`: cross-platform extension packaging against DuckDB `main` and `v1.5.2`.
+- `.github/workflows/dist_pipeline.yml`: cross-platform extension packaging against DuckDB `main` and `v1.5.4`.
 
 ## Architecture Notes
 

--- a/gaggle/Cargo.lock
+++ b/gaggle/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "gaggle"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "dirs",
  "mockito",

--- a/gaggle/Cargo.toml
+++ b/gaggle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaggle"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 edition = "2021"
 publish = false
 

--- a/gaggle/bindings/gaggle_extension.cpp
+++ b/gaggle/bindings/gaggle_extension.cpp
@@ -31,6 +31,8 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "duckdb.h"
@@ -43,6 +45,37 @@ namespace fs = std::filesystem;
 template <typename T>
 static T *GetFlatVectorDataWritable(Vector &vector) {
   return const_cast<T *>(FlatVector::GetData<T>(vector));
+}
+
+template <int N> struct PriorityTag : PriorityTag<N - 1> {};
+
+template <> struct PriorityTag<0> {};
+
+template <typename T = FunctionExpression>
+static auto MakeFunctionExpressionCompat(
+    const string &func_name, vector<unique_ptr<ParsedExpression>> children,
+    PriorityTag<1>)
+    -> decltype(make_uniq<T>(std::decay_t<decltype(std::declval<T>().FunctionName())>(
+                                 func_name),
+                             std::move(children))) {
+  using FunctionNameType =
+      std::decay_t<decltype(std::declval<T>().FunctionName())>;
+  return make_uniq<T>(FunctionNameType(func_name), std::move(children));
+}
+
+template <typename T = FunctionExpression>
+static auto MakeFunctionExpressionCompat(
+    const string &func_name, vector<unique_ptr<ParsedExpression>> children,
+    PriorityTag<0>)
+    -> decltype(make_uniq<T>(func_name, std::move(children))) {
+  return make_uniq<T>(func_name, std::move(children));
+}
+
+static unique_ptr<FunctionExpression>
+MakeFunctionExpressionCompat(const string &func_name,
+                             vector<unique_ptr<ParsedExpression>> children) {
+  return MakeFunctionExpressionCompat(func_name, std::move(children),
+                                      PriorityTag<1>{});
 }
 
 /**
@@ -635,8 +668,7 @@ KaggleReplacementScan(ClientContext &context, ReplacementScanInput &input,
   // Construct a table function call: func_name(local_path)
   vector<unique_ptr<ParsedExpression>> children;
   children.push_back(make_uniq<ConstantExpression>(Value(local_path)));
-  auto func_expr =
-      make_uniq<FunctionExpression>(func_name, std::move(children));
+  auto func_expr = MakeFunctionExpressionCompat(func_name, std::move(children));
 
   // Create a TableFunctionRef manually
   auto table_func_ref = make_uniq<TableFunctionRef>();

--- a/gaggle/bindings/gaggle_extension.cpp
+++ b/gaggle/bindings/gaggle_extension.cpp
@@ -948,7 +948,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 // Provide out-of-line definitions for the extension class
 void GaggleExtension::Load(ExtensionLoader &loader) { LoadInternal(loader); }
 std::string GaggleExtension::Name() { return "gaggle"; }
-std::string GaggleExtension::Version() const { return std::string("0.1.0-alpha.5"); }
+std::string GaggleExtension::Version() const { return std::string("0.1.0-alpha.6"); }
 
 } // namespace duckdb
 


### PR DESCRIPTION
* Updated build workflow for new DuckDB release (`v1.5.4`).